### PR TITLE
Fix TODO list showing below most other frames.

### DIFF
--- a/Nys_ToDoList/Assets/Scripts/UI/mainFrame.lua
+++ b/Nys_ToDoList/Assets/Scripts/UI/mainFrame.lua
@@ -1038,7 +1038,7 @@ function mainFrame:CreateTDLFrame()
 	-- // we create the list
 
 	-- properties
-	tdlFrame:SetFrameStrata("LOW")
+	tdlFrame:SetFrameStrata("DIALOG")
 	tdlFrame:EnableMouse(true)
 	tdlFrame:SetMovable(true)
 	tdlFrame:SetClampedToScreen(true)

--- a/Nys_ToDoList/Assets/Scripts/UI/widgets.lua
+++ b/Nys_ToDoList/Assets/Scripts/UI/widgets.lua
@@ -433,6 +433,7 @@ end
 
 function widgets:TutorialFrame(tutoCategory, tutoName, showCloseButton, arrowSide, text, width)
 	local tutoFrame = CreateFrame("Frame", "NysTDL_TutorialFrame_"..tutoCategory.."_"..tutoName, UIParent, "NysTDL_HelpPlateTooltip") -- TDLATER POLISH check if name is mandatory, also checl ALL addon names for the same thing
+	tutoFrame:SetFrameStrata("TOOLTIP")
 	tutoFrame.Text:SetText(text)
 	tutoFrame.Text:SetWidth(width-15-15)
 


### PR DESCRIPTION
Fix to show the TODO list at the dialog level.

# Before
Shows behind other frames like Bartender 4, Questie, Shadowed Unitframes, etc.
![Screenshot 2024-04-24 191738](https://github.com/Ny0n/Nys_ToDoList/assets/5498623/778dd82e-d919-440f-b2ea-b41a440d6be4)
![Screenshot 2024-04-24 191802](https://github.com/Ny0n/Nys_ToDoList/assets/5498623/93b36b44-2516-40b3-9a98-3ec4c47a4db1)

# After
Shows in front of frames like Bartender 4, Questie, Shadowed Unitframes, etc.
![Screenshot 2024-04-24 191521](https://github.com/Ny0n/Nys_ToDoList/assets/5498623/7b55d8bb-b542-4b25-9881-134c6bf0b6dc)
![Screenshot 2024-04-24 191625](https://github.com/Ny0n/Nys_ToDoList/assets/5498623/2a33f1e4-a080-4d39-8cd6-8f1526af0828)
